### PR TITLE
Emulate multipart upload with single-part uploads

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3ErrorCode.java
+++ b/src/main/java/org/gaul/s3proxy/S3ErrorCode.java
@@ -37,6 +37,10 @@ enum S3ErrorCode {
             "Your previous request to create the named bucket" +
             " succeeded and you already own it."),
     BUCKET_NOT_EMPTY(HttpServletResponse.SC_CONFLICT, "Conflict"),
+    ENTITY_TOO_SMALL(HttpServletResponse.SC_BAD_REQUEST,
+            "Your proposed upload is smaller than the minimum allowed object" +
+            " size. Each part must be at least 5 MB in size, except the last" +
+            " part."),
     INVALID_ACCESS_KEY_ID(HttpServletResponse.SC_FORBIDDEN, "Forbidden"),
     INVALID_ARGUMENT(HttpServletResponse.SC_BAD_REQUEST, "Bad Request"),
     INVALID_BUCKET_NAME(HttpServletResponse.SC_BAD_REQUEST, "Bad Request"),
@@ -52,6 +56,7 @@ enum S3ErrorCode {
             "Length Required"),
     NO_SUCH_BUCKET(HttpServletResponse.SC_NOT_FOUND, "Not Found"),
     NO_SUCH_KEY(HttpServletResponse.SC_NOT_FOUND, "Not Found"),
+    NO_SUCH_UPLOAD(HttpServletResponse.SC_NOT_FOUND, "Not Found"),
     REQUEST_TIME_TOO_SKEWED(HttpServletResponse.SC_FORBIDDEN, "Forbidden"),
     REQUEST_TIMEOUT(HttpServletResponse.SC_BAD_REQUEST, "Bad Request"),
     SIGNATURE_DOES_NOT_MATCH(HttpServletResponse.SC_FORBIDDEN, "Forbidden");

--- a/src/test/java/org/gaul/s3proxy/S3ProxyTest.java
+++ b/src/test/java/org/gaul/s3proxy/S3ProxyTest.java
@@ -52,6 +52,7 @@ import org.jclouds.io.Payload;
 import org.jclouds.io.payloads.ByteSourcePayload;
 import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
 import org.jclouds.rest.HttpClient;
+import org.jclouds.s3.S3Client;
 import org.jclouds.util.Throwables2;
 import org.junit.After;
 import org.junit.Before;
@@ -376,7 +377,7 @@ public final class S3ProxyTest {
     }
 
     @Test
-    public void testUnknownParameter() throws Exception {
+    public void testMultipartUpload() throws Exception {
         String blobName = "blob";
         int minMultipartSize = 32 * 1024 * 1024 + 1;
         ByteSource byteSource = ByteSource.wrap(new byte[minMultipartSize]);
@@ -384,9 +385,15 @@ public final class S3ProxyTest {
                 .payload(byteSource)
                 .contentLength(byteSource.size())
                 .build();
-        PutOptions options = new PutOptions().multipart(true);
+        s3BlobStore.putBlob(containerName, blob,
+                new PutOptions().multipart(true));
+    }
+
+    @Test
+    public void testUnknownParameter() throws Exception {
+        S3Client s3Client = s3Context.unwrapApi(S3Client.class);
         try {
-            s3BlobStore.putBlob(containerName, blob, options);
+            s3Client.disableBucketLogging(containerName);
             fail("Expected HttpResponseException");
         } catch (RuntimeException re) {
             // TODO: why does jclouds wrap this in a


### PR DESCRIPTION
This approach requires three times as many operations as the optimal
approach.  Implementing this correctly requires exposing the
underlying multipart operations in jclouds.  Most s3-tests pass but
two still fail:

test_multipart_upload_size_too_small
test_list_multipart_upload

References #2.