### PR TITLE
Expose the Jetty state in the S3Proxy interface.

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3Proxy.java
+++ b/src/main/java/org/gaul/s3proxy/S3Proxy.java
@@ -94,6 +94,10 @@ public final class S3Proxy {
         return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
     }
 
+    public String getState() {
+        return server.getState();
+    }
+
     public static void main(String[] args) throws Exception {
         if (args.length == 1 && args[0].equals("--version")) {
             System.err.println(

--- a/src/test/java/org/gaul/s3proxy/S3ProxyTest.java
+++ b/src/test/java/org/gaul/s3proxy/S3ProxyTest.java
@@ -34,6 +34,7 @@ import com.google.common.io.ByteSource;
 import com.google.common.io.Resources;
 import com.google.inject.Module;
 
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.jclouds.Constants;
 import org.jclouds.ContextBuilder;
 import org.jclouds.blobstore.BlobRequestSigner;
@@ -117,6 +118,10 @@ public final class S3ProxyTest {
                 keyStorePassword,
                 "true".equalsIgnoreCase(forceMultiPartUpload), virtualHost);
         s3Proxy.start();
+        while (s3Proxy.getState().equals(AbstractLifeCycle.RUNNING)) {
+            Thread.sleep(1);
+        }
+
         // reset endpoint to handle zero port
         s3Endpoint = new URI(s3Endpoint.getScheme(), s3Endpoint.getUserInfo(),
                 s3Endpoint.getHost(), s3Proxy.getPort(), s3Endpoint.getPath(),


### PR DESCRIPTION
The commit adds a getState() method, which exposes the Jetty state
to the caller. This is useful to check whether the server is running
or is in some other state.