### PR TITLE
Enable delimiter support.

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -848,7 +848,9 @@ final class S3ProxyHandler extends AbstractHandler {
             String containerName) throws IOException, S3Exception {
         ListContainerOptions options = new ListContainerOptions();
         String delimiter = request.getParameter("delimiter");
-        if (!(delimiter != null && delimiter.equals("/"))) {
+        if (delimiter != null) {
+            options.delimiter(delimiter);
+        } else {
             options.recursive();
         }
         String prefix = request.getParameter("prefix");

--- a/src/test/java/org/gaul/s3proxy/S3ProxyTest.java
+++ b/src/test/java/org/gaul/s3proxy/S3ProxyTest.java
@@ -229,7 +229,6 @@ public final class S3ProxyTest {
         assertThat(builder.build()).containsOnly("blob1", "blob2");
     }
 
-    @Ignore
     @Test
     public void testBlobListRecursive() throws Exception {
         assertThat(s3BlobStore.list(containerName)).isEmpty();
@@ -250,7 +249,7 @@ public final class S3ProxyTest {
         for (StorageMetadata metadata : s3BlobStore.list(containerName)) {
             builder.add(metadata.getName());
         }
-        assertThat(builder.build()).containsOnly("prefix");
+        assertThat(builder.build()).containsOnly("prefix/");
 
         builder = ImmutableSet.builder();
         for (StorageMetadata metadata : s3BlobStore.list(containerName,


### PR DESCRIPTION
Enables support for the delimiter option.

Amends a recursive test to expect that the delimiter is included in
the common prefix name.