### PR TITLE
Terminate on s3proxy start failure

### DIFF
--- a/src/main/java/org/gaul/s3proxy/Main.java
+++ b/src/main/java/org/gaul/s3proxy/Main.java
@@ -131,6 +131,11 @@ public final class Main {
             System.exit(1);
             throw e;
         }
-        s3Proxy.start();
+        try {
+            s3Proxy.start();
+        } catch (Exception e) {
+            System.err.println(e.getMessage());
+            System.exit(1);
+        }
     }
 }


### PR DESCRIPTION
E.g. when bind(2) fails.