### PR TITLE
For Azure backend, map Content-MD5 to  ETag for PUT blob

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -425,6 +425,9 @@ final class S3ProxyHandler extends AbstractHandler {
             if (headerName.startsWith("x-amz-meta-")) {
                 continue;
             }
+            if (headerName.startsWith("x-amz-content-")) {
+                continue;
+            }
             if (!SUPPORTED_X_AMZ_HEADERS.contains(headerName)) {
                 logger.error("Unknown header {} with URI {}",
                         headerName, request.getRequestURI());
@@ -1386,6 +1389,10 @@ final class S3ProxyHandler extends AbstractHandler {
                 }
             }
 
+            if (blobStoreType.equals("azureblob")) {
+                eTag = BaseEncoding.base16().lowerCase()
+                        .encode(BaseEncoding.base64().decode(contentMD5String));
+            }
             response.addHeader(HttpHeaders.ETAG, maybeQuoteETag(eTag));
         }
 


### PR DESCRIPTION
This fixes issue #96 