### PR TITLE
Add EventualBlobStore

### DIFF
--- a/src/main/java/org/gaul/s3proxy/EventualBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/EventualBlobStore.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2014-2016 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import static java.util.Objects.requireNonNull;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Deque;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.domain.Blob;
+import org.jclouds.blobstore.domain.BlobMetadata;
+import org.jclouds.blobstore.domain.MultipartPart;
+import org.jclouds.blobstore.domain.MultipartUpload;
+import org.jclouds.blobstore.options.CopyOptions;
+import org.jclouds.blobstore.options.CreateContainerOptions;
+import org.jclouds.blobstore.options.PutOptions;
+import org.jclouds.blobstore.util.ForwardingBlobStore;
+import org.jclouds.domain.Location;
+import org.jclouds.io.Payload;
+
+/**
+ * This class is a BlobStore wrapper which emulates eventual consistency
+ * using two blobstores.  It writes objects to one store and reads objects
+ * from another.  An asynchronous process copies objects between stores.  Note
+ * that container operations are not eventually consistent.
+ */
+final class EventualBlobStore extends ForwardingBlobStore {
+    private final BlobStore writeStore;  // read from delegate
+    private final ScheduledExecutorService executorService;
+    private final Deque<Callable<?>> deque = new ConcurrentLinkedDeque<>();
+    private final int delay;
+    private final TimeUnit delayUnit;
+    private final double probability;
+    private final Random random = new Random();
+
+    private EventualBlobStore(BlobStore writeStore, BlobStore readStore,
+            ScheduledExecutorService executorService, int delay,
+            TimeUnit delayUnit, double probability) {
+        super(readStore);
+        this.writeStore = requireNonNull(writeStore);
+        this.executorService = requireNonNull(executorService);
+        checkArgument(delay >= 0, "Delay must be at least zero, was: %s",
+                delay);
+        this.delay = delay;
+        this.delayUnit = requireNonNull(delayUnit);
+        checkArgument(probability >= 0.0 && probability <= 1.0,
+                "Probability must be between 0.0 and 1.0, was: %s",
+                probability);
+        this.probability = probability;
+    }
+
+    static BlobStore newEventualBlobStore(BlobStore writeStore,
+            BlobStore readStore, ScheduledExecutorService executorService,
+            int delay, TimeUnit delayUnit, double probability) {
+        return new EventualBlobStore(writeStore, readStore, executorService,
+                delay, delayUnit, probability);
+    }
+
+    @Override
+    public boolean createContainerInLocation(Location location,
+            String container, CreateContainerOptions options) {
+        return delegate().createContainerInLocation(
+                        location, container, options) &&
+                writeStore.createContainerInLocation(
+                        location, container, options);
+    }
+
+    @Override
+    public void deleteContainer(String container) {
+        delegate().deleteContainer(container);
+        writeStore.deleteContainer(container);
+    }
+
+    @Override
+    public boolean deleteContainerIfEmpty(String container) {
+        return delegate().deleteContainerIfEmpty(container) &&
+                writeStore.deleteContainerIfEmpty(container);
+    }
+
+    @Override
+    public String putBlob(String containerName, Blob blob) {
+        return putBlob(containerName, blob, PutOptions.NONE);
+    }
+
+    @Override
+    public String putBlob(final String containerName, Blob blob,
+            final PutOptions options) {
+        final String nearName = blob.getMetadata().getName();
+        String nearETag = writeStore.putBlob(containerName, blob, options);
+        schedule(new Callable<String>() {
+                @Override
+                public String call() {
+                    Blob nearBlob = writeStore.getBlob(containerName, nearName);
+                    String farETag = delegate().putBlob(containerName,
+                            nearBlob, options);
+                    return farETag;
+                }
+            });
+        return nearETag;
+    }
+
+    @Override
+    public void removeBlob(final String containerName, final String blobName) {
+        writeStore.removeBlob(containerName, blobName);
+        schedule(new Callable<Void>() {
+                @Override
+                public Void call() {
+                    delegate().removeBlob(containerName, blobName);
+                    return null;
+                }
+            });
+    }
+
+    @Override
+    public void removeBlobs(final String containerName,
+            final Iterable<String> blobNames) {
+        writeStore.removeBlobs(containerName, blobNames);
+        schedule(new Callable<Void>() {
+                @Override
+                public Void call() {
+                    delegate().removeBlobs(containerName, blobNames);
+                    return null;
+                }
+            });
+    }
+
+    @Override
+    public String copyBlob(final String fromContainer, final String fromName,
+            final String toContainer, final String toName,
+            final CopyOptions options) {
+        String nearETag = writeStore.copyBlob(fromContainer, fromName,
+                toContainer, toName, options);
+        schedule(new Callable<String>() {
+                @Override
+                public String call() {
+                    return delegate().copyBlob(fromContainer, fromName,
+                            toContainer, toName, options);
+                }
+            });
+        return nearETag;
+    }
+
+    @Override
+    public MultipartUpload initiateMultipartUpload(String container,
+            BlobMetadata blobMetadata, PutOptions options) {
+        MultipartUpload mpu = delegate().initiateMultipartUpload(container,
+                blobMetadata, options);
+        return mpu;
+    }
+
+    @Override
+    public void abortMultipartUpload(MultipartUpload mpu) {
+        delegate().abortMultipartUpload(mpu);
+    }
+
+    @Override
+    public String completeMultipartUpload(final MultipartUpload mpu,
+            final List<MultipartPart> parts) {
+        schedule(new Callable<String>() {
+                @Override
+                public String call() {
+                    String farETag = delegate().completeMultipartUpload(mpu,
+                            parts);
+                    return farETag;
+                }
+            });
+        return "";  // TODO: fake ETag
+    }
+
+    @Override
+    public MultipartPart uploadMultipartPart(MultipartUpload mpu,
+            int partNumber, Payload payload) {
+        MultipartPart part = delegate().uploadMultipartPart(mpu, partNumber,
+                payload);
+        return part;
+    }
+
+    private void schedule(Callable<?> callable) {
+        if (random.nextDouble() < probability) {
+            deque.add(callable);
+            executorService.schedule(new DequeCallable(), delay, delayUnit);
+        }
+    }
+
+    private final class DequeCallable implements Callable<Void> {
+        @Override
+        public Void call() throws Exception {
+            deque.poll().call();
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
@@ -41,6 +41,20 @@ public final class S3ProxyConstants {
             "s3proxy.virtual-host";
     public static final String PROPERTY_V4_MAX_NON_CHUNKED_REQUEST_SIZE =
             "s3proxy.v4-max-non-chunked-request-size";
+    /** When true, model eventual consistency using two storage backends. */
+    public static final String PROPERTY_EVENTUAL_CONSISTENCY =
+            "s3proxy.eventual-consistency";
+    /**
+     * Minimum delay, in seconds, when propagating modifications from the
+     * write backend to the read backend.
+     */
+    public static final String PROPERTY_EVENTUAL_CONSISTENCY_DELAY =
+            "s3proxy.eventual-consistency.delay";
+    /** Probability of eventual consistency, between 0.0 and 1.0. */
+    public static final String PROPERTY_EVENTUAL_CONSISTENCY_PROBABILITY =
+            "s3proxy.eventual-consistency.probability";
+
+    static final String PROPERTY_ALT_JCLOUDS_PREFIX = "alt.";
 
     private S3ProxyConstants() {
         throw new AssertionError("Cannot instantiate utility constructor");

--- a/src/test/java/org/gaul/s3proxy/EventualBlobStoreTest.java
+++ b/src/test/java/org/gaul/s3proxy/EventualBlobStoreTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2014-2016 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.Hashing;
+import com.google.common.io.ByteSource;
+import com.google.common.net.MediaType;
+import com.google.inject.Module;
+
+import org.jclouds.ContextBuilder;
+import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.BlobStoreContext;
+import org.jclouds.blobstore.domain.Blob;
+import org.jclouds.blobstore.domain.MultipartPart;
+import org.jclouds.blobstore.domain.MultipartUpload;
+import org.jclouds.blobstore.options.CopyOptions;
+import org.jclouds.blobstore.options.PutOptions;
+import org.jclouds.io.ContentMetadata;
+import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public final class EventualBlobStoreTest {
+    private static final int DELAY = 5;
+    private static final TimeUnit DELAY_UNIT = TimeUnit.SECONDS;
+    private static final ByteSource BYTE_SOURCE =
+            TestUtils.randomByteSource().slice(0, 1024);
+    private BlobStoreContext nearContext;
+    private BlobStoreContext farContext;
+    private BlobStore nearBlobStore;
+    private BlobStore farBlobStore;
+    private String containerName;
+    private ScheduledExecutorService executorService;
+    private BlobStore eventualBlobStore;
+
+    @Before
+    public void setUp() throws Exception {
+        containerName = createRandomContainerName();
+
+        nearContext = ContextBuilder
+                .newBuilder("transient")
+                .credentials("identity", "credential")
+                .modules(ImmutableList.<Module>of(new SLF4JLoggingModule()))
+                .build(BlobStoreContext.class);
+        nearBlobStore = nearContext.getBlobStore();
+        nearBlobStore.createContainerInLocation(null, containerName);
+
+        farContext = ContextBuilder
+                .newBuilder("transient")
+                .credentials("identity", "credential")
+                .modules(ImmutableList.<Module>of(new SLF4JLoggingModule()))
+                .build(BlobStoreContext.class);
+        farBlobStore = farContext.getBlobStore();
+        farBlobStore.createContainerInLocation(null, containerName);
+
+        executorService = Executors.newScheduledThreadPool(1);
+
+        eventualBlobStore = EventualBlobStore.newEventualBlobStore(
+                nearBlobStore, farBlobStore, executorService, DELAY,
+                DELAY_UNIT, 1.0);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (nearContext != null) {
+            nearBlobStore.deleteContainer(containerName);
+            nearContext.close();
+        }
+        if (farContext != null) {
+            farBlobStore.deleteContainer(containerName);
+            farContext.close();
+        }
+        if (executorService != null) {
+            executorService.shutdown();
+        }
+    }
+
+    @Test
+    public void testReadAfterCreate() throws Exception {
+        String blobName = createRandomBlobName();
+        Blob blob = makeBlob(eventualBlobStore, blobName);
+        eventualBlobStore.putBlob(containerName, blob);
+        assertThat(eventualBlobStore.getBlob(containerName, blobName))
+                .isNull();
+        delay();
+        validateBlob(eventualBlobStore.getBlob(containerName, blobName));
+    }
+
+    @Test
+    public void testReadAfterDelete() throws Exception {
+        String blobName = createRandomBlobName();
+        Blob blob = makeBlob(eventualBlobStore, blobName);
+        eventualBlobStore.putBlob(containerName, blob);
+        assertThat(eventualBlobStore.getBlob(containerName, blobName))
+                .isNull();
+        delay();
+        eventualBlobStore.removeBlob(containerName, blobName);
+        validateBlob(eventualBlobStore.getBlob(containerName, blobName));
+        delay();
+        assertThat(eventualBlobStore.getBlob(containerName, blobName))
+                .isNull();
+    }
+
+    @Test
+    public void testOverwriteAfterDelete() throws Exception {
+        String blobName = createRandomBlobName();
+        Blob blob = makeBlob(eventualBlobStore, blobName);
+        eventualBlobStore.putBlob(containerName, blob);
+        delay();
+        eventualBlobStore.removeBlob(containerName, blobName);
+        blob = makeBlob(eventualBlobStore, blobName);
+        eventualBlobStore.putBlob(containerName, blob);
+        delay();
+        validateBlob(eventualBlobStore.getBlob(containerName, blobName));
+    }
+
+    @Test
+    public void testReadAfterCopy() throws Exception {
+        String fromName = createRandomBlobName();
+        String toName = createRandomBlobName();
+        Blob blob = makeBlob(eventualBlobStore, fromName);
+        eventualBlobStore.putBlob(containerName, blob);
+        delay();
+        eventualBlobStore.copyBlob(containerName, fromName, containerName,
+                toName, CopyOptions.NONE);
+        assertThat(eventualBlobStore.getBlob(containerName, toName))
+                .isNull();
+        delay();
+        validateBlob(eventualBlobStore.getBlob(containerName, toName));
+    }
+
+    @Test
+    public void testReadAfterMultipartUpload() throws Exception {
+        String blobName = createRandomBlobName();
+        Blob blob = makeBlob(eventualBlobStore, blobName);
+        MultipartUpload mpu = eventualBlobStore.initiateMultipartUpload(
+                containerName, blob.getMetadata(), new PutOptions());
+        MultipartPart part = eventualBlobStore.uploadMultipartPart(mpu,
+                /*partNumber=*/ 1, blob.getPayload());
+        eventualBlobStore.completeMultipartUpload(mpu, ImmutableList.of(part));
+        assertThat(eventualBlobStore.getBlob(containerName, blobName))
+                .isNull();
+        delay();
+        validateBlob(eventualBlobStore.getBlob(containerName, blobName));
+    }
+
+    @Test
+    public void testListAfterCreate() throws Exception {
+        String blobName = createRandomBlobName();
+        Blob blob = makeBlob(eventualBlobStore, blobName);
+        eventualBlobStore.putBlob(containerName, blob);
+        assertThat(eventualBlobStore.list(containerName)).isEmpty();
+        delay();
+        assertThat(eventualBlobStore.list(containerName)).isNotEmpty();
+    }
+
+    private static String createRandomContainerName() {
+        return "container-" + new Random().nextInt(Integer.MAX_VALUE);
+    }
+
+    private static String createRandomBlobName() {
+        return "blob-" + new Random().nextInt(Integer.MAX_VALUE);
+    }
+
+    private static Blob makeBlob(BlobStore blobStore, String blobName)
+            throws IOException {
+        return blobStore.blobBuilder(blobName)
+                .payload(BYTE_SOURCE)
+                .contentDisposition("attachment; filename=foo.mp4")
+                .contentEncoding("compress")
+                .contentLength(BYTE_SOURCE.size())
+                .contentType(MediaType.MP4_AUDIO)
+                .contentMD5(BYTE_SOURCE.hash(Hashing.md5()))
+                .userMetadata(ImmutableMap.of("key", "value"))
+                .build();
+    }
+
+    private static void validateBlob(Blob blob) throws IOException {
+        assertThat(blob).isNotNull();
+
+        ContentMetadata contentMetadata =
+                blob.getMetadata().getContentMetadata();
+        assertThat(contentMetadata.getContentDisposition())
+                .isEqualTo("attachment; filename=foo.mp4");
+        assertThat(contentMetadata.getContentEncoding())
+                .isEqualTo("compress");
+        assertThat(contentMetadata.getContentLength())
+                .isEqualTo(BYTE_SOURCE.size());
+        assertThat(contentMetadata.getContentType())
+                .isEqualTo(MediaType.MP4_AUDIO.toString());
+
+        assertThat(blob.getMetadata().getUserMetadata())
+                .isEqualTo(ImmutableMap.of("key", "value"));
+
+        try (InputStream actual = blob.getPayload().openStream();
+                InputStream expected = BYTE_SOURCE.openStream()) {
+            assertThat(actual).hasContentEqualTo(expected);
+        }
+    }
+
+    private static void delay() throws InterruptedException {
+        DELAY_UNIT.sleep(1 + DELAY);
+    }
+}


### PR DESCRIPTION
This models eventually-consistent behavior.  This implementation uses
two buckets and with client writes going to the first bucket and reads
to the second.  Operations are replicated from the first to the second
with a variable delays.  A more complete implementation could flap
between the strongly- and eventually-consistent buckets and arbitrary
reorder operations which conclude with last-writer wins.  Fixes #65.