### PR TITLE
support for S3 response header overrides

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -156,7 +156,13 @@ final class S3ProxyHandler extends AbstractHandler {
             "prefix",
             "Signature",
             "uploadId",
-            "uploads"
+            "uploads",
+            "response-cache-control",
+            "response-content-disposition",
+            "response-content-encoding",
+            "response-content-language",
+            "response-content-type",
+            "response-expires"
     );
     /** All supported x-amz- headers, except for x-amz-meta- user metadata. */
     private static final Set<String> SUPPORTED_X_AMZ_HEADERS = ImmutableSet.of(
@@ -1381,7 +1387,7 @@ final class S3ProxyHandler extends AbstractHandler {
         }
 
         response.setStatus(HttpServletResponse.SC_OK);
-        addMetadataToResponse(response, metadata);
+        addMetadataToResponse(request, response, metadata);
     }
 
     private void handleGetBlob(HttpServletRequest request,
@@ -1442,7 +1448,7 @@ final class S3ProxyHandler extends AbstractHandler {
 
         response.setStatus(status);
 
-        addMetadataToResponse(response, blob.getMetadata());
+        addMetadataToResponse(request, response, blob.getMetadata());
         // TODO: handles only a single range due to jclouds limitations
         Collection<String> contentRanges =
                 blob.getAllHeaders().get(HttpHeaders.CONTENT_RANGE);
@@ -2365,21 +2371,48 @@ final class S3ProxyHandler extends AbstractHandler {
         }
     }
 
-    private static void addMetadataToResponse(HttpServletResponse response,
+    private static void addResponseHeaderWithOverride(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            String headerName,
+            String overrideHeaderName,
+            String value) {
+        String override = request.getParameter(overrideHeaderName);
+        response.addHeader(headerName, override != null ? override : value);
+    }
+
+    private static void addMetadataToResponse(HttpServletRequest request,
+            HttpServletResponse response,
             BlobMetadata metadata) {
         ContentMetadata contentMetadata =
                 metadata.getContentMetadata();
-        response.addHeader(HttpHeaders.CACHE_CONTROL,
+        addResponseHeaderWithOverride(request,
+                response,
+                HttpHeaders.CACHE_CONTROL,
+                "response-cache-control",
                 contentMetadata.getCacheControl());
-        response.addHeader(HttpHeaders.CONTENT_DISPOSITION,
-                contentMetadata.getContentDisposition());
-        response.addHeader(HttpHeaders.CONTENT_ENCODING,
+        addResponseHeaderWithOverride(request,
+                response,
+                HttpHeaders.CONTENT_ENCODING,
+                "response-content-encoding",
                 contentMetadata.getContentEncoding());
-        response.addHeader(HttpHeaders.CONTENT_LANGUAGE,
+        addResponseHeaderWithOverride(request,
+                response,
+                HttpHeaders.CONTENT_LANGUAGE,
+                "response-content-language",
                 contentMetadata.getContentLanguage());
+        addResponseHeaderWithOverride(request,
+                response,
+                HttpHeaders.CONTENT_DISPOSITION,
+                "response-content-disposition",
+                contentMetadata.getContentDisposition());
         response.addHeader(HttpHeaders.CONTENT_LENGTH,
                 contentMetadata.getContentLength().toString());
-        response.setContentType(contentMetadata.getContentType());
+        String overrideContentType = request.getParameter(
+                "response-content-type");
+        response.setContentType(overrideContentType != null ?
+                overrideContentType :
+                contentMetadata.getContentType());
         HashCode contentMd5 = contentMetadata.getContentMD5AsHashCode();
         if (contentMd5 != null) {
             byte[] contentMd5Bytes = contentMd5.asBytes();
@@ -2388,9 +2421,14 @@ final class S3ProxyHandler extends AbstractHandler {
             response.addHeader(HttpHeaders.ETAG, maybeQuoteETag(
                     BaseEncoding.base16().lowerCase().encode(contentMd5Bytes)));
         }
-        Date expires = contentMetadata.getExpires();
-        if (expires != null) {
-            response.addDateHeader(HttpHeaders.EXPIRES, expires.getTime());
+        String overrideExpires = request.getParameter("response-expires");
+        if (overrideExpires != null) {
+            response.addHeader(HttpHeaders.EXPIRES, overrideExpires);
+        } else {
+            Date expires = contentMetadata.getExpires();
+            if (expires != null) {
+                response.addDateHeader(HttpHeaders.EXPIRES, expires.getTime());
+            }
         }
         response.addDateHeader(HttpHeaders.LAST_MODIFIED,
                 metadata.getLastModified().getTime());

--- a/src/test/java/org/gaul/s3proxy/S3AwsSdkTest.java
+++ b/src/test/java/org/gaul/s3proxy/S3AwsSdkTest.java
@@ -51,6 +51,7 @@ import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 import com.amazonaws.services.s3.model.CompleteMultipartUploadResult;
 import com.amazonaws.services.s3.model.CopyPartRequest;
 import com.amazonaws.services.s3.model.CopyPartResult;
+import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.GroupGrantee;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
@@ -58,6 +59,7 @@ import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.Permission;
+import com.amazonaws.services.s3.model.ResponseHeaderOverrides;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.UploadPartRequest;
@@ -458,6 +460,47 @@ public final class S3AwsSdkTest {
                 InputStream expected = BYTE_SOURCE.openStream()) {
             assertThat(actual).hasContentEqualTo(expected);
         }
+    }
+
+    @Test
+    public void testOverrideResponseHeader() throws Exception {
+        String blobName = "foo";
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(BYTE_SOURCE.size());
+        client.putObject(containerName, blobName, BYTE_SOURCE.openStream(),
+                metadata);
+
+        String cacheControl = "no-cache";
+        String contentDisposition = "attachment; filename=foo.html";
+        String contentEncoding = "gzip";
+        String contentLanguage = "en";
+        String contentType = "text/html; charset=UTF-8";
+        String expires = "Wed, 13 Jul 2016 21:23:51 GMT";
+        long expiresTime = 1468445031000L;
+        GetObjectRequest getObjectRequest = new GetObjectRequest(containerName,
+                blobName);
+        getObjectRequest.setResponseHeaders(
+                new ResponseHeaderOverrides()
+                    .withCacheControl(cacheControl)
+                    .withContentDisposition(contentDisposition)
+                    .withContentEncoding(contentEncoding)
+                    .withContentLanguage(contentLanguage)
+                    .withContentType(contentType)
+                    .withExpires(expires));
+        S3Object object = client.getObject(getObjectRequest);
+        ObjectMetadata reponseMetadata = object.getObjectMetadata();
+        assertThat(reponseMetadata.getCacheControl()).isEqualTo(
+                cacheControl);
+        assertThat(reponseMetadata.getContentDisposition()).isEqualTo(
+                contentDisposition);
+        assertThat(reponseMetadata.getContentEncoding()).isEqualTo(
+                contentEncoding);
+        assertThat(reponseMetadata.getContentLanguage()).isEqualTo(
+                contentLanguage);
+        assertThat(reponseMetadata.getContentType()).isEqualTo(
+                contentType);
+        assertThat(reponseMetadata.getHttpExpiresDate().getTime())
+            .isEqualTo(expiresTime);
     }
 
     private static final class NullX509TrustManager


### PR DESCRIPTION
I added support for `response-content-disposition` request query parameter in object GETs.
See details: https://forums.aws.amazon.com/ann.jspa?annID=884

I also added a simple Dockerfile to support a docker development environment based on the official [maven docker image](https://hub.docker.com/_/maven/). You can then run `docker build -t s3proxy-build -f Dockerfile.build .` to build and test s3proxy. This encapsulates java and maven dependencies quite nicely.