### PR TITLE
Added logger.error instead of logger.debug in sendSimpleErrorResponse…

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -2405,7 +2405,7 @@ final class S3ProxyHandler extends AbstractHandler {
             HttpServletRequest request, HttpServletResponse response,
             S3ErrorCode code, String message,
             Map<String, String> elements) throws IOException {
-        logger.debug("{} {}", code, elements);
+        logger.error("{} {}", code, elements);
 
         response.setStatus(code.getHttpStatusCode());
 


### PR DESCRIPTION
This change helps to debug why something is failing from logs