### PR TITLE
S3proxy presigned url fail with override parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>2.17</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>7.3</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>check</id>

--- a/src/main/java/org/gaul/s3proxy/AbstractS3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/AbstractS3ProxyHandler.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2014-2016 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jclouds.blobstore.BlobStore;
+
+
+
+public abstract class AbstractS3ProxyHandler {
+    protected abstract void handleGetContainerAcl(
+            HttpServletResponse response, BlobStore blobStore,
+            String containerName) throws IOException;
+
+    protected abstract void handleSetContainerAcl(
+            HttpServletRequest request, HttpServletResponse response,
+            InputStream is, BlobStore blobStore,
+            String containerName) throws IOException, S3Exception;
+
+    protected abstract void handleGetBlobAcl(
+            HttpServletResponse response, BlobStore blobStore,
+            String containerName,
+            String blobName) throws IOException;
+
+    protected abstract void handleSetBlobAcl(
+            HttpServletRequest request, HttpServletResponse response,
+            InputStream is, BlobStore blobStore,
+            String containerName, String blobName)
+            throws IOException, S3Exception;
+
+    protected abstract void handleContainerList(
+            HttpServletResponse response,
+            BlobStore blobStore) throws IOException;
+
+    protected abstract void handleContainerLocation(
+            HttpServletResponse response, BlobStore blobStore,
+            String containerName) throws IOException;
+
+    protected abstract void handleListMultipartUploads(
+            HttpServletRequest request, HttpServletResponse response,
+            BlobStore blobStore,
+            String container) throws IOException, S3Exception;
+
+    protected abstract void handleContainerExists(
+            BlobStore blobStore, String containerName)
+            throws IOException, S3Exception;
+
+    protected abstract void handleContainerCreate(
+            HttpServletRequest request, HttpServletResponse response,
+            InputStream is, BlobStore blobStore,
+            String containerName) throws IOException, S3Exception;
+
+    protected abstract void handleContainerDelete(
+            HttpServletResponse response, BlobStore blobStore,
+            String containerName) throws IOException, S3Exception;
+
+    protected abstract void handleBlobList(
+            HttpServletRequest request, HttpServletResponse response,
+            BlobStore blobStore, String containerName)
+            throws IOException, S3Exception;
+
+    protected abstract void handleBlobRemove(
+            HttpServletResponse response, BlobStore blobStore,
+            String containerName,
+            String blobName) throws IOException, S3Exception;
+
+    protected abstract void handleMultiBlobRemove(
+            HttpServletResponse response, InputStream is,
+            BlobStore blobStore, String containerName) throws IOException;
+
+    protected abstract void handleBlobMetadata(
+            HttpServletRequest request, HttpServletResponse response,
+            BlobStore blobStore, String containerName,
+            String blobName) throws IOException, S3Exception;
+
+    protected abstract void handleGetBlob(
+            HttpServletRequest request, HttpServletResponse response,
+            BlobStore blobStore, String containerName, String blobName)
+            throws IOException, S3Exception;
+
+    protected abstract void handleCopyBlob(
+            HttpServletRequest request, HttpServletResponse response,
+            InputStream is, BlobStore blobStore,
+            String destContainerName, String destBlobName)
+            throws IOException, S3Exception;
+
+    protected abstract void handlePutBlob(
+            HttpServletRequest request, HttpServletResponse response,
+            InputStream is, BlobStore blobStore,
+            String containerName, String blobName)
+            throws IOException, S3Exception;
+
+    protected abstract void handlePostBlob(
+            HttpServletRequest request, HttpServletResponse response,
+            InputStream is, BlobStore blobStore, String containerName)
+            throws IOException, S3Exception;
+
+    protected abstract void handleInitiateMultipartUpload(
+            HttpServletRequest request, HttpServletResponse response,
+            BlobStore blobStore, String containerName, String blobName)
+            throws IOException, S3Exception;
+
+    protected abstract void handleCompleteMultipartUpload(
+            HttpServletResponse response, InputStream is,
+            BlobStore blobStore, String containerName,
+            String blobName, String uploadId) throws IOException, S3Exception;
+
+    protected abstract void handleAbortMultipartUpload(
+            HttpServletResponse response, BlobStore blobStore,
+            String containerName, String blobName,
+            String uploadId) throws IOException, S3Exception;
+
+    protected abstract void handleListParts(
+            HttpServletRequest request, HttpServletResponse response,
+            BlobStore blobStore, String containerName,
+            String blobName, String uploadId) throws IOException, S3Exception;
+
+    protected abstract void handleCopyPart(
+            HttpServletRequest request, HttpServletResponse response,
+            BlobStore blobStore, String containerName,
+            String blobName, String uploadId) throws IOException, S3Exception;
+
+    protected abstract void handleUploadPart(
+            HttpServletRequest request, HttpServletResponse response,
+            InputStream is, BlobStore blobStore,
+            String containerName, String blobName, String uploadId)
+            throws IOException, S3Exception;
+}

--- a/src/main/java/org/gaul/s3proxy/AbstractS3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/AbstractS3ProxyHandler.java
@@ -28,8 +28,8 @@ import org.jclouds.blobstore.BlobStore;
 
 public abstract class AbstractS3ProxyHandler {
     protected abstract void handleGetContainerAcl(
-            HttpServletResponse response, BlobStore blobStore,
-            String containerName) throws IOException;
+            HttpServletRequest request, HttpServletResponse response,
+            BlobStore blobStore, String containerName) throws IOException;
 
     protected abstract void handleSetContainerAcl(
             HttpServletRequest request, HttpServletResponse response,
@@ -37,8 +37,8 @@ public abstract class AbstractS3ProxyHandler {
             String containerName) throws IOException, S3Exception;
 
     protected abstract void handleGetBlobAcl(
-            HttpServletResponse response, BlobStore blobStore,
-            String containerName,
+            HttpServletRequest request, HttpServletResponse response,
+            BlobStore blobStore, String containerName,
             String blobName) throws IOException;
 
     protected abstract void handleSetBlobAcl(
@@ -48,12 +48,12 @@ public abstract class AbstractS3ProxyHandler {
             throws IOException, S3Exception;
 
     protected abstract void handleContainerList(
-            HttpServletResponse response,
+            HttpServletRequest request, HttpServletResponse response,
             BlobStore blobStore) throws IOException;
 
     protected abstract void handleContainerLocation(
-            HttpServletResponse response, BlobStore blobStore,
-            String containerName) throws IOException;
+            HttpServletRequest request, HttpServletResponse response,
+            BlobStore blobStore, String containerName) throws IOException;
 
     protected abstract void handleListMultipartUploads(
             HttpServletRequest request, HttpServletResponse response,
@@ -61,6 +61,7 @@ public abstract class AbstractS3ProxyHandler {
             String container) throws IOException, S3Exception;
 
     protected abstract void handleContainerExists(
+            HttpServletRequest request, HttpServletResponse response,
             BlobStore blobStore, String containerName)
             throws IOException, S3Exception;
 
@@ -70,8 +71,9 @@ public abstract class AbstractS3ProxyHandler {
             String containerName) throws IOException, S3Exception;
 
     protected abstract void handleContainerDelete(
-            HttpServletResponse response, BlobStore blobStore,
-            String containerName) throws IOException, S3Exception;
+            HttpServletRequest request, HttpServletResponse response,
+            BlobStore blobStore, String containerName)
+            throws IOException, S3Exception;
 
     protected abstract void handleBlobList(
             HttpServletRequest request, HttpServletResponse response,
@@ -79,13 +81,14 @@ public abstract class AbstractS3ProxyHandler {
             throws IOException, S3Exception;
 
     protected abstract void handleBlobRemove(
-            HttpServletResponse response, BlobStore blobStore,
-            String containerName,
+            HttpServletRequest request, HttpServletResponse response,
+            BlobStore blobStore, String containerName,
             String blobName) throws IOException, S3Exception;
 
     protected abstract void handleMultiBlobRemove(
-            HttpServletResponse response, InputStream is,
-            BlobStore blobStore, String containerName) throws IOException;
+            HttpServletRequest request, HttpServletResponse response,
+            InputStream is, BlobStore blobStore,
+            String containerName) throws IOException;
 
     protected abstract void handleBlobMetadata(
             HttpServletRequest request, HttpServletResponse response,
@@ -120,13 +123,13 @@ public abstract class AbstractS3ProxyHandler {
             throws IOException, S3Exception;
 
     protected abstract void handleCompleteMultipartUpload(
-            HttpServletResponse response, InputStream is,
-            BlobStore blobStore, String containerName,
+            HttpServletRequest request, HttpServletResponse response,
+            InputStream is, BlobStore blobStore, String containerName,
             String blobName, String uploadId) throws IOException, S3Exception;
 
     protected abstract void handleAbortMultipartUpload(
-            HttpServletResponse response, BlobStore blobStore,
-            String containerName, String blobName,
+            HttpServletRequest request,  HttpServletResponse response,
+            BlobStore blobStore, String containerName, String blobName,
             String uploadId) throws IOException, S3Exception;
 
     protected abstract void handleListParts(

--- a/src/main/java/org/gaul/s3proxy/Main.java
+++ b/src/main/java/org/gaul/s3proxy/Main.java
@@ -96,6 +96,9 @@ public final class Main {
             System.exit(1);
         }
 
+        String s3ProxyServicePath = properties.getProperty(
+                S3ProxyConstants.PROPERTY_SERVICE_PATH);
+
         AuthenticationType s3ProxyAuthorization =
                 AuthenticationType.fromString(s3ProxyAuthorizationString);
         String localIdentity = null;
@@ -200,6 +203,9 @@ public final class Main {
             if (corsAllowAll != null) {
                 s3ProxyBuilder.corsAllowAll(Boolean.parseBoolean(
                         corsAllowAll));
+            }
+            if (s3ProxyServicePath != null) {
+                s3ProxyBuilder.servicePath(s3ProxyServicePath);
             }
             s3Proxy = s3ProxyBuilder.build();
         } catch (IllegalArgumentException | IllegalStateException e) {

--- a/src/main/java/org/gaul/s3proxy/S3Proxy.java
+++ b/src/main/java/org/gaul/s3proxy/S3Proxy.java
@@ -76,7 +76,7 @@ public final class S3Proxy {
 
         server = new Server();
 
-        if (!builder.servicePath.isEmpty()) {
+        if (builder.servicePath != null && !builder.servicePath.isEmpty()) {
             // Add a single handler on context "/hello"
             ContextHandler context = new ContextHandler();
             context.setContextPath(builder.servicePath);

--- a/src/main/java/org/gaul/s3proxy/S3Proxy.java
+++ b/src/main/java/org/gaul/s3proxy/S3Proxy.java
@@ -28,6 +28,7 @@ import com.google.common.base.Strings;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.jclouds.blobstore.BlobStore;
@@ -74,6 +75,13 @@ public final class S3Proxy {
                 "Must provide both identity and credential");
 
         server = new Server();
+
+        if (!builder.servicePath.isEmpty()) {
+            // Add a single handler on context "/hello"
+            ContextHandler context = new ContextHandler();
+            context.setContextPath(builder.servicePath);
+        }
+
         ((QueuedThreadPool) server.getThreadPool()).setName("S3Proxy");
         HttpConnectionFactory httpConnectionFactory =
                 new HttpConnectionFactory();
@@ -105,7 +113,8 @@ public final class S3Proxy {
                 builder.authenticationType, builder.identity,
                 builder.credential, Optional.fromNullable(builder.virtualHost),
                 builder.v4MaxNonChunkedRequestSize,
-                builder.ignoreUnknownHeaders, builder.corsAllowAll);
+                builder.ignoreUnknownHeaders, builder.corsAllowAll,
+                builder.servicePath);
         server.setHandler(handler);
     }
 
@@ -120,6 +129,7 @@ public final class S3Proxy {
         private String keyStorePath;
         private String keyStorePassword;
         private String virtualHost;
+        private String servicePath;
         private long v4MaxNonChunkedRequestSize = 32 * 1024 * 1024;
         private boolean ignoreUnknownHeaders;
         private boolean corsAllowAll;
@@ -184,6 +194,20 @@ public final class S3Proxy {
         public Builder corsAllowAll(boolean corsAllowAll) {
             this.corsAllowAll = corsAllowAll;
             return this;
+        }
+
+        public void servicePath(String s3ProxyServicePath) {
+            String path = Strings.nullToEmpty(s3ProxyServicePath);
+
+            if (!path.isEmpty()) {
+                if (path.equals("/")) {
+                    path = "";
+                } else if (!path.startsWith("/")) {
+                    path = "/" + path;
+                }
+            }
+
+            this.servicePath = path;
         }
     }
 

--- a/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
@@ -25,6 +25,8 @@ public final class S3ProxyConstants {
             "s3proxy.authorization";
     public static final String PROPERTY_IDENTITY =
             "s3proxy.identity";
+    public static final String PROPERTY_SERVICE_PATH =
+            "s3proxy.service-path";
     /** When true, include "Access-Control-Allow-Origin: *" in all responses. */
     public static final String PROPERTY_CORS_ALLOW_ALL =
             "s3proxy.cors-allow-all";

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -110,7 +110,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** HTTP server-independent handler for S3 requests. */
-public class S3ProxyHandler {
+public class S3ProxyHandler extends AbstractS3ProxyHandler {
     private static final Logger logger = LoggerFactory.getLogger(
             S3ProxyHandler.class);
     private static final String AWS_XMLNS =
@@ -672,7 +672,8 @@ public class S3ProxyHandler {
         throw new S3Exception(S3ErrorCode.NOT_IMPLEMENTED);
     }
 
-    private void handleGetContainerAcl(HttpServletResponse response,
+    @Override
+    protected void handleGetContainerAcl(HttpServletResponse response,
             BlobStore blobStore, String containerName) throws IOException {
         ContainerAccess access = blobStore.getContainerAccess(containerName);
 
@@ -731,7 +732,8 @@ public class S3ProxyHandler {
         }
     }
 
-    private void handleSetContainerAcl(HttpServletRequest request,
+    @Override
+    protected void handleSetContainerAcl(HttpServletRequest request,
             HttpServletResponse response, InputStream is, BlobStore blobStore,
             String containerName) throws IOException, S3Exception {
         ContainerAccess access;
@@ -767,7 +769,8 @@ public class S3ProxyHandler {
         blobStore.setContainerAccess(containerName, access);
     }
 
-    private void handleGetBlobAcl(HttpServletResponse response,
+    @Override
+    protected void handleGetBlobAcl(HttpServletResponse response,
             BlobStore blobStore, String containerName,
             String blobName) throws IOException {
         BlobAccess access = blobStore.getBlobAccess(containerName, blobName);
@@ -827,7 +830,8 @@ public class S3ProxyHandler {
         }
     }
 
-    private void handleSetBlobAcl(HttpServletRequest request,
+    @Override
+    protected void handleSetBlobAcl(HttpServletRequest request,
             HttpServletResponse response, InputStream is, BlobStore blobStore,
             String containerName, String blobName)
             throws IOException, S3Exception {
@@ -901,7 +905,8 @@ public class S3ProxyHandler {
         }
     }
 
-    private void handleContainerList(HttpServletResponse response,
+    @Override
+    protected void handleContainerList(HttpServletResponse response,
             BlobStore blobStore) throws IOException {
         PageSet<? extends StorageMetadata> buckets = blobStore.list();
 
@@ -942,7 +947,8 @@ public class S3ProxyHandler {
         }
     }
 
-    private void handleContainerLocation(HttpServletResponse response,
+    @Override
+    protected void handleContainerLocation(HttpServletResponse response,
             BlobStore blobStore, String containerName) throws IOException {
         try (Writer writer = response.getWriter()) {
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -958,7 +964,8 @@ public class S3ProxyHandler {
         }
     }
 
-    private void handleListMultipartUploads(HttpServletRequest request,
+    @Override
+    protected void handleListMultipartUploads(HttpServletRequest request,
             HttpServletResponse response, BlobStore blobStore,
             String container) throws IOException, S3Exception {
         if (request.getParameter("delimiter") != null ||
@@ -1018,14 +1025,16 @@ public class S3ProxyHandler {
         }
     }
 
-    private void handleContainerExists(BlobStore blobStore,
+    @Override
+    protected void handleContainerExists(BlobStore blobStore,
             String containerName) throws IOException, S3Exception {
         if (!blobStore.containerExists(containerName)) {
             throw new S3Exception(S3ErrorCode.NO_SUCH_BUCKET);
         }
     }
 
-    private void handleContainerCreate(HttpServletRequest request,
+    @Override
+    protected void handleContainerCreate(HttpServletRequest request,
             HttpServletResponse response, InputStream is, BlobStore blobStore,
             String containerName) throws IOException, S3Exception {
         if (containerName.isEmpty()) {
@@ -1103,7 +1112,8 @@ public class S3ProxyHandler {
         response.addHeader(HttpHeaders.LOCATION, "/" + containerName);
     }
 
-    private void handleContainerDelete(HttpServletResponse response,
+    @Override
+    protected void handleContainerDelete(HttpServletResponse response,
             BlobStore blobStore, String containerName)
             throws IOException, S3Exception {
         if (!blobStore.containerExists(containerName)) {
@@ -1127,7 +1137,8 @@ public class S3ProxyHandler {
         response.setStatus(HttpServletResponse.SC_NO_CONTENT);
     }
 
-    private void handleBlobList(HttpServletRequest request,
+    @Override
+    protected void handleBlobList(HttpServletRequest request,
             HttpServletResponse response, BlobStore blobStore,
             String containerName) throws IOException, S3Exception {
         String blobStoreType = getBlobStoreType(blobStore);
@@ -1273,14 +1284,16 @@ public class S3ProxyHandler {
         }
     }
 
-    private void handleBlobRemove(HttpServletResponse response,
+    @Override
+    protected void handleBlobRemove(HttpServletResponse response,
             BlobStore blobStore, String containerName,
             String blobName) throws IOException, S3Exception {
         blobStore.removeBlob(containerName, blobName);
         response.sendError(HttpServletResponse.SC_NO_CONTENT);
     }
 
-    private void handleMultiBlobRemove(HttpServletResponse response,
+    @Override
+    protected void handleMultiBlobRemove(HttpServletResponse response,
             InputStream is, BlobStore blobStore, String containerName)
             throws IOException {
         DeleteMultipleObjectsRequest dmor = new XmlMapper().readValue(
@@ -1318,7 +1331,8 @@ public class S3ProxyHandler {
         }
     }
 
-    private void handleBlobMetadata(HttpServletRequest request,
+    @Override
+    protected void handleBlobMetadata(HttpServletRequest request,
             HttpServletResponse response,
             BlobStore blobStore, String containerName,
             String blobName) throws IOException, S3Exception {
@@ -1365,7 +1379,8 @@ public class S3ProxyHandler {
         addMetadataToResponse(request, response, metadata);
     }
 
-    private void handleGetBlob(HttpServletRequest request,
+    @Override
+    protected void handleGetBlob(HttpServletRequest request,
             HttpServletResponse response, BlobStore blobStore,
             String containerName, String blobName)
             throws IOException, S3Exception {
@@ -1445,7 +1460,8 @@ public class S3ProxyHandler {
         }
     }
 
-    private void handleCopyBlob(HttpServletRequest request,
+    @Override
+    protected void handleCopyBlob(HttpServletRequest request,
             HttpServletResponse response, InputStream is, BlobStore blobStore,
             String destContainerName, String destBlobName)
             throws IOException, S3Exception {
@@ -1564,7 +1580,8 @@ public class S3ProxyHandler {
         }
     }
 
-    private void handlePutBlob(HttpServletRequest request,
+    @Override
+    protected void handlePutBlob(HttpServletRequest request,
             HttpServletResponse response, InputStream is, BlobStore blobStore,
             String containerName, String blobName)
             throws IOException, S3Exception {
@@ -1690,7 +1707,8 @@ public class S3ProxyHandler {
         response.addHeader(HttpHeaders.ETAG, maybeQuoteETag(eTag));
     }
 
-    private void handlePostBlob(HttpServletRequest request,
+    @Override
+    protected void handlePostBlob(HttpServletRequest request,
             HttpServletResponse response, InputStream is, BlobStore blobStore,
             String containerName)
             throws IOException, S3Exception {
@@ -1792,7 +1810,8 @@ public class S3ProxyHandler {
         response.setStatus(HttpServletResponse.SC_NO_CONTENT);
     }
 
-    private void handleInitiateMultipartUpload(HttpServletRequest request,
+    @Override
+    protected void handleInitiateMultipartUpload(HttpServletRequest request,
             HttpServletResponse response, BlobStore blobStore,
             String containerName, String blobName)
             throws IOException, S3Exception {
@@ -1844,7 +1863,8 @@ public class S3ProxyHandler {
         }
     }
 
-    private void handleCompleteMultipartUpload(HttpServletResponse response,
+    @Override
+    protected void handleCompleteMultipartUpload(HttpServletResponse response,
             InputStream is, BlobStore blobStore, String containerName,
             String blobName, String uploadId) throws IOException, S3Exception {
         Blob stubBlob = blobStore.getBlob(containerName, uploadId);
@@ -1935,7 +1955,8 @@ public class S3ProxyHandler {
         }
     }
 
-    private void handleAbortMultipartUpload(HttpServletResponse response,
+    @Override
+    protected void handleAbortMultipartUpload(HttpServletResponse response,
             BlobStore blobStore, String containerName, String blobName,
             String uploadId) throws IOException, S3Exception {
         if (!blobStore.blobExists(containerName, uploadId)) {
@@ -1952,7 +1973,8 @@ public class S3ProxyHandler {
         response.sendError(HttpServletResponse.SC_NO_CONTENT);
     }
 
-    private void handleListParts(HttpServletRequest request,
+    @Override
+    protected void handleListParts(HttpServletRequest request,
             HttpServletResponse response, BlobStore blobStore,
             String containerName, String blobName, String uploadId)
             throws IOException, S3Exception {
@@ -2046,7 +2068,8 @@ public class S3ProxyHandler {
         }
     }
 
-    private void handleCopyPart(HttpServletRequest request,
+    @Override
+    protected void handleCopyPart(HttpServletRequest request,
             HttpServletResponse response, BlobStore blobStore,
             String containerName, String blobName, String uploadId)
             throws IOException, S3Exception {
@@ -2219,7 +2242,8 @@ public class S3ProxyHandler {
         }
     }
 
-    private void handleUploadPart(HttpServletRequest request,
+    @Override
+    protected void handleUploadPart(HttpServletRequest request,
             HttpServletResponse response, InputStream is, BlobStore blobStore,
             String containerName, String blobName, String uploadId)
             throws IOException, S3Exception {

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -140,7 +140,14 @@ public class S3ProxyHandler extends AbstractS3ProxyHandler {
     private static final Set<String> SIGNED_SUBRESOURCES = ImmutableSet.of(
             "acl", "delete", "lifecycle", "location", "logging", "notification",
             "partNumber", "policy", "requestPayment", "torrent", "uploadId",
-            "uploads", "versionId", "versioning", "versions", "website"
+            "uploads", "versionId", "versioning", "versions", "website",
+            // Added from com.amazonaws.services.s3.internal.RestUtils
+            "tagging", "cors", "restore", "replication", "accelerate",
+            "inventory", "analytics", "metrics",
+            // Override-response-header parameters aslo need be signed
+            "response-content-type", "response-content-language",
+            "response-expires", "response-cache-control",
+            "response-content-disposition", "response-content-encoding"
     );
     private static final Set<String> SUPPORTED_PARAMETERS = ImmutableSet.of(
             "acl",

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -496,26 +496,29 @@ public class S3ProxyHandler extends AbstractS3ProxyHandler {
         switch (method) {
         case "DELETE":
             if (path.length <= 2 || path[2].isEmpty()) {
-                handleContainerDelete(response, blobStore, path[1]);
+                handleContainerDelete(request, response, blobStore, path[1]);
                 return;
             } else if (uploadId != null) {
-                handleAbortMultipartUpload(response, blobStore, path[1],
-                        path[2], uploadId);
+                handleAbortMultipartUpload(request, response, blobStore,
+                        path[1], path[2], uploadId);
                 return;
             } else {
-                handleBlobRemove(response, blobStore, path[1], path[2]);
+                handleBlobRemove(request, response, blobStore,
+                        path[1], path[2]);
                 return;
             }
         case "GET":
             if (uri.equals("/")) {
-                handleContainerList(response, blobStore);
+                handleContainerList(request, response, blobStore);
                 return;
             } else if (path.length <= 2 || path[2].isEmpty()) {
                 if ("".equals(request.getParameter("acl"))) {
-                    handleGetContainerAcl(response, blobStore, path[1]);
+                    handleGetContainerAcl(request,
+                            response, blobStore, path[1]);
                     return;
                 } else if ("".equals(request.getParameter("location"))) {
-                    handleContainerLocation(response, blobStore, path[1]);
+                    handleContainerLocation(request,
+                            response, blobStore, path[1]);
                     return;
                 } else if ("".equals(request.getParameter("uploads"))) {
                     handleListMultipartUploads(request, response, blobStore,
@@ -526,7 +529,7 @@ public class S3ProxyHandler extends AbstractS3ProxyHandler {
                 return;
             } else {
                 if ("".equals(request.getParameter("acl"))) {
-                    handleGetBlobAcl(response, blobStore, path[1],
+                    handleGetBlobAcl(request, response, blobStore, path[1],
                             path[2]);
                     return;
                 } else if (uploadId != null) {
@@ -540,7 +543,7 @@ public class S3ProxyHandler extends AbstractS3ProxyHandler {
             }
         case "HEAD":
             if (path.length <= 2 || path[2].isEmpty()) {
-                handleContainerExists(blobStore, path[1]);
+                handleContainerExists(request, response, blobStore, path[1]);
                 return;
             } else {
                 handleBlobMetadata(request, response, blobStore, path[1],
@@ -549,7 +552,8 @@ public class S3ProxyHandler extends AbstractS3ProxyHandler {
             }
         case "POST":
             if ("".equals(request.getParameter("delete"))) {
-                handleMultiBlobRemove(response, is, blobStore, path[1]);
+                handleMultiBlobRemove(request, response,
+                        is, blobStore, path[1]);
                 return;
             } else if ("".equals(request.getParameter("uploads"))) {
                 handleInitiateMultipartUpload(request, response, blobStore,
@@ -557,8 +561,8 @@ public class S3ProxyHandler extends AbstractS3ProxyHandler {
                 return;
             } else if (uploadId != null &&
                     request.getParameter("partNumber") == null) {
-                handleCompleteMultipartUpload(response, is, blobStore, path[1],
-                        path[2], uploadId);
+                handleCompleteMultipartUpload(request, response,
+                        is, blobStore, path[1], path[2], uploadId);
                 return;
             }
             break;
@@ -612,7 +616,7 @@ public class S3ProxyHandler extends AbstractS3ProxyHandler {
         switch (method) {
         case "GET":
             if (uri.equals("/")) {
-                handleContainerList(response, blobStore);
+                handleContainerList(request, response, blobStore);
                 return;
             } else if (path.length <= 2 || path[2].isEmpty()) {
                 String containerName = path[1];
@@ -673,7 +677,8 @@ public class S3ProxyHandler extends AbstractS3ProxyHandler {
     }
 
     @Override
-    protected void handleGetContainerAcl(HttpServletResponse response,
+    protected void handleGetContainerAcl(
+            HttpServletRequest request, HttpServletResponse response,
             BlobStore blobStore, String containerName) throws IOException {
         ContainerAccess access = blobStore.getContainerAccess(containerName);
 
@@ -770,7 +775,8 @@ public class S3ProxyHandler extends AbstractS3ProxyHandler {
     }
 
     @Override
-    protected void handleGetBlobAcl(HttpServletResponse response,
+    protected void handleGetBlobAcl(
+            HttpServletRequest request, HttpServletResponse response,
             BlobStore blobStore, String containerName,
             String blobName) throws IOException {
         BlobAccess access = blobStore.getBlobAccess(containerName, blobName);
@@ -906,7 +912,8 @@ public class S3ProxyHandler extends AbstractS3ProxyHandler {
     }
 
     @Override
-    protected void handleContainerList(HttpServletResponse response,
+    protected void handleContainerList(
+            HttpServletRequest request, HttpServletResponse response,
             BlobStore blobStore) throws IOException {
         PageSet<? extends StorageMetadata> buckets = blobStore.list();
 
@@ -948,7 +955,8 @@ public class S3ProxyHandler extends AbstractS3ProxyHandler {
     }
 
     @Override
-    protected void handleContainerLocation(HttpServletResponse response,
+    protected void handleContainerLocation(
+            HttpServletRequest request, HttpServletResponse response,
             BlobStore blobStore, String containerName) throws IOException {
         try (Writer writer = response.getWriter()) {
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -1026,7 +1034,9 @@ public class S3ProxyHandler extends AbstractS3ProxyHandler {
     }
 
     @Override
-    protected void handleContainerExists(BlobStore blobStore,
+    protected void handleContainerExists(
+            HttpServletRequest request, HttpServletResponse response,
+            BlobStore blobStore,
             String containerName) throws IOException, S3Exception {
         if (!blobStore.containerExists(containerName)) {
             throw new S3Exception(S3ErrorCode.NO_SUCH_BUCKET);
@@ -1113,7 +1123,8 @@ public class S3ProxyHandler extends AbstractS3ProxyHandler {
     }
 
     @Override
-    protected void handleContainerDelete(HttpServletResponse response,
+    protected void handleContainerDelete(
+            HttpServletRequest request, HttpServletResponse response,
             BlobStore blobStore, String containerName)
             throws IOException, S3Exception {
         if (!blobStore.containerExists(containerName)) {
@@ -1285,7 +1296,8 @@ public class S3ProxyHandler extends AbstractS3ProxyHandler {
     }
 
     @Override
-    protected void handleBlobRemove(HttpServletResponse response,
+    protected void handleBlobRemove(
+            HttpServletRequest request, HttpServletResponse response,
             BlobStore blobStore, String containerName,
             String blobName) throws IOException, S3Exception {
         blobStore.removeBlob(containerName, blobName);
@@ -1293,7 +1305,8 @@ public class S3ProxyHandler extends AbstractS3ProxyHandler {
     }
 
     @Override
-    protected void handleMultiBlobRemove(HttpServletResponse response,
+    protected void handleMultiBlobRemove(
+            HttpServletRequest request, HttpServletResponse response,
             InputStream is, BlobStore blobStore, String containerName)
             throws IOException {
         DeleteMultipleObjectsRequest dmor = new XmlMapper().readValue(
@@ -1864,7 +1877,8 @@ public class S3ProxyHandler extends AbstractS3ProxyHandler {
     }
 
     @Override
-    protected void handleCompleteMultipartUpload(HttpServletResponse response,
+    protected void handleCompleteMultipartUpload(
+            HttpServletRequest request, HttpServletResponse response,
             InputStream is, BlobStore blobStore, String containerName,
             String blobName, String uploadId) throws IOException, S3Exception {
         Blob stubBlob = blobStore.getBlob(containerName, uploadId);
@@ -1956,7 +1970,8 @@ public class S3ProxyHandler extends AbstractS3ProxyHandler {
     }
 
     @Override
-    protected void handleAbortMultipartUpload(HttpServletResponse response,
+    protected void handleAbortMultipartUpload(
+            HttpServletRequest request, HttpServletResponse response,
             BlobStore blobStore, String containerName, String blobName,
             String uploadId) throws IOException, S3Exception {
         if (!blobStore.blobExists(containerName, uploadId)) {

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandlerJetty.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandlerJetty.java
@@ -44,10 +44,10 @@ final class S3ProxyHandlerJetty extends AbstractHandler {
             AuthenticationType authenticationType, final String identity,
             final String credential, Optional<String> virtualHost,
             long v4MaxNonChunkedRequestSize, boolean ignoreUnknownHeaders,
-            boolean corsAllowAll) {
+            boolean corsAllowAll, String servicePath) {
         handler = new S3ProxyHandler(blobStore, authenticationType, identity,
                 credential, virtualHost, v4MaxNonChunkedRequestSize,
-                ignoreUnknownHeaders, corsAllowAll);
+                ignoreUnknownHeaders, corsAllowAll, servicePath);
     }
 
     @Override

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -28,7 +28,9 @@
     <module name="CovariantEquals"/>
     <module name="DeclarationOrder"/>
     <module name="DefaultComesLast"/>
-    <module name="DesignForExtension"/>
+    <module name="DesignForExtension">
+      <property name="ignoredAnnotations" value="Override"/>
+    </module>
     <module name="EmptyBlock">
       <property name="option" value="text"/>
     </module>

--- a/src/test/java/org/gaul/s3proxy/JcloudsBucketsLiveTest.java
+++ b/src/test/java/org/gaul/s3proxy/JcloudsBucketsLiveTest.java
@@ -31,6 +31,7 @@ import org.assertj.core.api.Fail;
 import org.jclouds.Constants;
 import org.jclouds.aws.AWSResponseException;
 import org.jclouds.blobstore.BlobStoreContext;
+import org.jclouds.s3.reference.S3Constants;
 import org.jclouds.s3.services.BucketsLiveTest;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
@@ -75,9 +76,11 @@ public final class JcloudsBucketsLiveTest extends BucketsLiveTest {
         props.setProperty(Constants.PROPERTY_CREDENTIAL,
                 info.getS3Credential());
         props.setProperty(Constants.PROPERTY_ENDPOINT,
-                info.getEndpoint().toString());
+                info.getEndpoint().toString() + info.getServicePath());
         props.setProperty(Constants.PROPERTY_STRIP_EXPECT_HEADER, "true");
-        endpoint = info.getEndpoint().toString();
+        props.setProperty(S3Constants.PROPERTY_S3_SERVICE_PATH,
+                info.getServicePath());
+        endpoint = info.getEndpoint().toString() + info.getServicePath();
         return props;
     }
 

--- a/src/test/java/org/gaul/s3proxy/JcloudsS3BlobIntegrationLiveTest.java
+++ b/src/test/java/org/gaul/s3proxy/JcloudsS3BlobIntegrationLiveTest.java
@@ -26,6 +26,7 @@ import org.jclouds.Constants;
 import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.s3.blobstore.integration.S3BlobIntegrationLiveTest;
+import org.jclouds.s3.reference.S3Constants;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -70,7 +71,9 @@ public final class JcloudsS3BlobIntegrationLiveTest
         props.setProperty(Constants.PROPERTY_CREDENTIAL,
                 info.getS3Credential());
         props.setProperty(Constants.PROPERTY_ENDPOINT,
-                info.getEndpoint().toString());
+                info.getEndpoint().toString() + info.getServicePath());
+        props.setProperty(S3Constants.PROPERTY_S3_SERVICE_PATH,
+                info.getServicePath());
         props.setProperty(Constants.PROPERTY_STRIP_EXPECT_HEADER, "true");
         return props;
     }

--- a/src/test/java/org/gaul/s3proxy/JcloudsS3BlobSignerLiveTest.java
+++ b/src/test/java/org/gaul/s3proxy/JcloudsS3BlobSignerLiveTest.java
@@ -28,6 +28,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import org.jclouds.Constants;
 import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.s3.blobstore.integration.S3BlobSignerLiveTest;
+import org.jclouds.s3.reference.S3Constants;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -69,7 +70,9 @@ public final class JcloudsS3BlobSignerLiveTest extends S3BlobSignerLiveTest {
         props.setProperty(Constants.PROPERTY_CREDENTIAL,
                 info.getS3Credential());
         props.setProperty(Constants.PROPERTY_ENDPOINT,
-                info.getEndpoint().toString());
+                info.getEndpoint().toString() + info.getServicePath());
+        props.setProperty(S3Constants.PROPERTY_S3_SERVICE_PATH,
+                info.getServicePath());
         props.setProperty(Constants.PROPERTY_STRIP_EXPECT_HEADER, "true");
         endpoint = info.getEndpoint().toString();
         return props;

--- a/src/test/java/org/gaul/s3proxy/JcloudsS3ClientLiveTest.java
+++ b/src/test/java/org/gaul/s3proxy/JcloudsS3ClientLiveTest.java
@@ -35,6 +35,7 @@ import org.jclouds.aws.AWSResponseException;
 import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.s3.S3ClientLiveTest;
 import org.jclouds.s3.domain.S3Object;
+import org.jclouds.s3.reference.S3Constants;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -78,9 +79,11 @@ public final class JcloudsS3ClientLiveTest extends S3ClientLiveTest {
         props.setProperty(Constants.PROPERTY_CREDENTIAL,
                 info.getS3Credential());
         props.setProperty(Constants.PROPERTY_ENDPOINT,
-                info.getEndpoint().toString());
+                info.getEndpoint().toString() + info.getServicePath());
         props.setProperty(Constants.PROPERTY_STRIP_EXPECT_HEADER, "true");
-        endpoint = info.getEndpoint().toString();
+        props.setProperty(S3Constants.PROPERTY_S3_SERVICE_PATH,
+                info.getServicePath());
+        endpoint = info.getEndpoint().toString() + info.getServicePath();
         return props;
     }
 

--- a/src/test/java/org/gaul/s3proxy/JcloudsS3ContainerIntegrationLiveTest.java
+++ b/src/test/java/org/gaul/s3proxy/JcloudsS3ContainerIntegrationLiveTest.java
@@ -25,6 +25,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import org.jclouds.Constants;
 import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.s3.blobstore.integration.S3ContainerIntegrationLiveTest;
+import org.jclouds.s3.reference.S3Constants;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -69,7 +70,9 @@ public final class JcloudsS3ContainerIntegrationLiveTest
         props.setProperty(Constants.PROPERTY_CREDENTIAL,
                 info.getS3Credential());
         props.setProperty(Constants.PROPERTY_ENDPOINT,
-                info.getEndpoint().toString());
+                info.getEndpoint().toString() + info.getServicePath());
+        props.setProperty(S3Constants.PROPERTY_S3_SERVICE_PATH,
+                info.getServicePath());
         props.setProperty(Constants.PROPERTY_STRIP_EXPECT_HEADER, "true");
         return props;
     }

--- a/src/test/java/org/gaul/s3proxy/S3AwsSdkTest.java
+++ b/src/test/java/org/gaul/s3proxy/S3AwsSdkTest.java
@@ -97,6 +97,7 @@ public final class S3AwsSdkTest {
     private String containerName;
     private BasicAWSCredentials awsCreds;
     private AmazonS3 client;
+    private String servicePath;
 
     @Before
     public void setUp() throws Exception {
@@ -108,7 +109,8 @@ public final class S3AwsSdkTest {
         s3Endpoint = info.getEndpoint();
         client = new AmazonS3Client(awsCreds,
                 new ClientConfiguration());
-        client.setEndpoint(s3Endpoint.toString());
+        client.setEndpoint(s3Endpoint.toString() + info.getServicePath());
+        servicePath = info.getServicePath();
 
         containerName = createRandomContainerName();
         info.getBlobStore().createContainerInLocation(null, containerName);
@@ -137,7 +139,7 @@ public final class S3AwsSdkTest {
     public void testAwsV2Signature() throws Exception {
         client = new AmazonS3Client(awsCreds,
                 new ClientConfiguration().withSignerOverride("S3SignerType"));
-        client.setEndpoint(s3Endpoint.toString());
+        client.setEndpoint(s3Endpoint.toString() + servicePath);
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(BYTE_SOURCE.size());
         client.putObject(containerName, "foo", BYTE_SOURCE.openStream(),
@@ -155,7 +157,7 @@ public final class S3AwsSdkTest {
     @Test
     public void testAwsV4Signature() throws Exception {
         client = new AmazonS3Client(awsCreds);
-        client.setEndpoint(s3Endpoint.toString());
+        client.setEndpoint(s3Endpoint.toString() + servicePath);
 
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(BYTE_SOURCE.size());
@@ -174,7 +176,7 @@ public final class S3AwsSdkTest {
     @Test
     public void testAwsV4SignatureNonChunked() throws Exception {
         client = new AmazonS3Client(awsCreds);
-        client.setEndpoint(s3Endpoint.toString());
+        client.setEndpoint(s3Endpoint.toString() + servicePath);
         client.setS3ClientOptions(
                 S3ClientOptions.builder().disableChunkedEncoding().build());
 
@@ -196,7 +198,7 @@ public final class S3AwsSdkTest {
     public void testAwsV4SignatureBadIdentity() throws Exception {
         client = new AmazonS3Client(new BasicAWSCredentials(
                 "bad-identity", awsCreds.getAWSSecretKey()));
-        client.setEndpoint(s3Endpoint.toString());
+        client.setEndpoint(s3Endpoint.toString() + servicePath);
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(BYTE_SOURCE.size());
 
@@ -213,7 +215,7 @@ public final class S3AwsSdkTest {
     public void testAwsV4SignatureBadCredential() throws Exception {
         client = new AmazonS3Client(new BasicAWSCredentials(
                 awsCreds.getAWSAccessKeyId(), "bad-credential"));
-        client.setEndpoint(s3Endpoint.toString());
+        client.setEndpoint(s3Endpoint.toString() + servicePath);
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(BYTE_SOURCE.size());
 
@@ -233,7 +235,7 @@ public final class S3AwsSdkTest {
     public void testAwsV2UrlSigning() throws Exception {
         client = new AmazonS3Client(awsCreds,
                 new ClientConfiguration().withSignerOverride("S3SignerType"));
-        client.setEndpoint(s3Endpoint.toString());
+        client.setEndpoint(s3Endpoint.toString() + servicePath);
 
         String blobName = "foo";
         ObjectMetadata metadata = new ObjectMetadata();

--- a/src/test/java/org/gaul/s3proxy/S3AwsSdkTest.java
+++ b/src/test/java/org/gaul/s3proxy/S3AwsSdkTest.java
@@ -53,6 +53,7 @@ import com.amazonaws.services.s3.model.CopyPartRequest;
 import com.amazonaws.services.s3.model.CopyPartResult;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsResult;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.GroupGrantee;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
@@ -135,8 +136,9 @@ public final class S3AwsSdkTest {
         }
     }
 
+
     @Test
-    public void testAwsV2Signature() throws Exception {
+    public void testAwsV2SignatureWithOverrideParameters() throws Exception {
         client = new AmazonS3Client(awsCreds,
                 new ClientConfiguration().withSignerOverride("S3SignerType"));
         client.setEndpoint(s3Endpoint.toString() + servicePath);
@@ -145,14 +147,33 @@ public final class S3AwsSdkTest {
         client.putObject(containerName, "foo", BYTE_SOURCE.openStream(),
                 metadata);
 
-        S3Object object = client.getObject(containerName, "foo");
+        String blobName = "foo";
+
+        ResponseHeaderOverrides headerOverride = new ResponseHeaderOverrides();
+
+        String expectedContentDisposition = "attachment; " + blobName;
+        headerOverride.setContentDisposition(expectedContentDisposition);
+
+        String expectedContentType = "text/plain";
+        headerOverride.setContentType(expectedContentType);
+
+        GetObjectRequest request = new GetObjectRequest(containerName,
+                blobName);
+        request.setResponseHeaders(headerOverride);
+
+        S3Object object = client.getObject(request);
         assertThat(object.getObjectMetadata().getContentLength()).isEqualTo(
                 BYTE_SOURCE.size());
+        assertThat(object.getObjectMetadata().getContentDisposition())
+                .isEqualTo(expectedContentDisposition);
+        assertThat(object.getObjectMetadata().getContentType()).isEqualTo(
+                expectedContentType);
         try (InputStream actual = object.getObjectContent();
-                InputStream expected = BYTE_SOURCE.openStream()) {
+             InputStream expected = BYTE_SOURCE.openStream()) {
             assertThat(actual).hasContentEqualTo(expected);
         }
     }
+
 
     @Test
     public void testAwsV4Signature() throws Exception {
@@ -249,6 +270,39 @@ public final class S3AwsSdkTest {
                 expiration, HttpMethod.GET);
         try (InputStream actual = url.openStream();
                 InputStream expected = BYTE_SOURCE.openStream()) {
+            assertThat(actual).hasContentEqualTo(expected);
+        }
+    }
+
+    @Test
+    public void testAwsV2UrlSigningWithOverrideParameters() throws Exception {
+        client = new AmazonS3Client(awsCreds,
+                new ClientConfiguration().withSignerOverride("S3SignerType"));
+        client.setEndpoint(s3Endpoint.toString() + servicePath);
+
+        String blobName = "foo";
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(BYTE_SOURCE.size());
+        client.putObject(containerName, blobName, BYTE_SOURCE.openStream(),
+                metadata);
+
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(containerName, blobName);
+        generatePresignedUrlRequest.setMethod(HttpMethod.GET);
+
+        ResponseHeaderOverrides headerOverride = new ResponseHeaderOverrides();
+
+        headerOverride.setContentDisposition("attachment; " + blobName);
+        headerOverride.setContentType("text/plain");
+        generatePresignedUrlRequest.setResponseHeaders(headerOverride);
+
+        Date expiration = new Date(System.currentTimeMillis() +
+                TimeUnit.HOURS.toMillis(1));
+        generatePresignedUrlRequest.setExpiration(expiration);
+
+        URL url = client.generatePresignedUrl(generatePresignedUrlRequest);
+        try (InputStream actual = url.openStream();
+             InputStream expected = BYTE_SOURCE.openStream()) {
             assertThat(actual).hasContentEqualTo(expected);
         }
     }

--- a/src/test/java/org/gaul/s3proxy/TestUtils.java
+++ b/src/test/java/org/gaul/s3proxy/TestUtils.java
@@ -110,6 +110,7 @@ final class TestUtils {
         private String s3Credential;
         private BlobStore blobStore;
         private URI endpoint;
+        private String servicePath;
 
         S3Proxy getS3Proxy() {
             return s3Proxy;
@@ -125,6 +126,10 @@ final class TestUtils {
 
         String getS3Credential() {
             return s3Credential;
+        }
+
+        String getServicePath() {
+            return servicePath;
         }
 
         BlobStore getBlobStore() {
@@ -178,6 +183,11 @@ final class TestUtils {
                 S3ProxyConstants.PROPERTY_KEYSTORE_PASSWORD);
         String virtualHost = info.getProperties().getProperty(
                 S3ProxyConstants.PROPERTY_VIRTUAL_HOST);
+        String servicePath = Strings.nullToEmpty(info.getProperties()
+                .getProperty(S3ProxyConstants.PROPERTY_SERVICE_PATH));
+        info.servicePath = servicePath.equals("/") ? "" :
+                (servicePath.startsWith("/") ? servicePath :
+                        servicePath.isEmpty() ? "" : "/" + servicePath);
 
         ContextBuilder builder = ContextBuilder
                 .newBuilder(provider)
@@ -207,6 +217,9 @@ final class TestUtils {
         }
         if (virtualHost != null) {
             s3ProxyBuilder.virtualHost(virtualHost);
+        }
+        if (servicePath != null) {
+            s3ProxyBuilder.servicePath(servicePath);
         }
         info.s3Proxy = s3ProxyBuilder.build();
         info.s3Proxy.start();

--- a/src/test/resources/s3proxy.conf
+++ b/src/test/resources/s3proxy.conf
@@ -1,5 +1,6 @@
 s3proxy.endpoint=http://127.0.0.1:0
 s3proxy.secure-endpoint=https://127.0.0.1:0
+#s3proxy.service-path=s3proxy
 # authorization must be aws-v2, aws-v4, aws-v2-or-v4, or none
 s3proxy.authorization=aws-v2-or-v4
 s3proxy.identity=local-identity


### PR DESCRIPTION
This change makes S3Proxy able to validate presigned url which has override parameters, i.e. "content-disposition", "response-content-encoding".