### PR TITLE
Add support for ignoring unknown parameters

### DIFF
--- a/src/main/java/org/gaul/s3proxy/Main.java
+++ b/src/main/java/org/gaul/s3proxy/Main.java
@@ -134,6 +134,8 @@ public final class Main {
                 S3ProxyConstants.PROPERTY_V4_MAX_NON_CHUNKED_REQUEST_SIZE);
         String ignoreUnknownHeaders = properties.getProperty(
                 S3ProxyConstants.PROPERTY_IGNORE_UNKNOWN_HEADERS);
+        String ignoreUnknownParameters = properties.getProperty(
+                S3ProxyConstants.PROPERTY_IGNORE_UNKNOWN_PARAMETERS);
         String corsAllowAll = properties.getProperty(
                 S3ProxyConstants.PROPERTY_CORS_ALLOW_ALL);
 
@@ -196,6 +198,10 @@ public final class Main {
             if (ignoreUnknownHeaders != null) {
                 s3ProxyBuilder.ignoreUnknownHeaders(Boolean.parseBoolean(
                         ignoreUnknownHeaders));
+            }
+            if (ignoreUnknownParameters != null) {
+                s3ProxyBuilder.ignoreUnknownParameters(Boolean.parseBoolean(
+                        ignoreUnknownParameters));
             }
             if (corsAllowAll != null) {
                 s3ProxyBuilder.corsAllowAll(Boolean.parseBoolean(

--- a/src/main/java/org/gaul/s3proxy/S3Proxy.java
+++ b/src/main/java/org/gaul/s3proxy/S3Proxy.java
@@ -105,7 +105,8 @@ public final class S3Proxy {
                 builder.authenticationType, builder.identity,
                 builder.credential, Optional.fromNullable(builder.virtualHost),
                 builder.v4MaxNonChunkedRequestSize,
-                builder.ignoreUnknownHeaders, builder.corsAllowAll);
+                builder.ignoreUnknownHeaders, builder.ignoreUnknownParameters,
+                builder.corsAllowAll);
         server.setHandler(handler);
     }
 
@@ -122,6 +123,7 @@ public final class S3Proxy {
         private String virtualHost;
         private long v4MaxNonChunkedRequestSize = 32 * 1024 * 1024;
         private boolean ignoreUnknownHeaders;
+        private boolean ignoreUnknownParameters;
         private boolean corsAllowAll;
 
         Builder() {
@@ -178,6 +180,12 @@ public final class S3Proxy {
 
         public Builder ignoreUnknownHeaders(boolean ignoreUnknownHeaders) {
             this.ignoreUnknownHeaders = ignoreUnknownHeaders;
+            return this;
+        }
+
+        public Builder ignoreUnknownParameters(
+                boolean ignoreUnknownParameters) {
+            this.ignoreUnknownParameters = ignoreUnknownParameters;
             return this;
         }
 

--- a/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
@@ -32,6 +32,8 @@ public final class S3ProxyConstants {
             "s3proxy.credential";
     public static final String PROPERTY_IGNORE_UNKNOWN_HEADERS =
             "s3proxy.ignore-unknown-headers";
+    public static final String PROPERTY_IGNORE_UNKNOWN_PARAMETERS =
+            "s3proxy.ignore-unknown-parameters";
     public static final String PROPERTY_KEYSTORE_PATH =
             "s3proxy.keystore-path";
     public static final String PROPERTY_KEYSTORE_PASSWORD =

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -198,6 +198,7 @@ public class S3ProxyHandler {
     private final Optional<String> virtualHost;
     private final long v4MaxNonChunkedRequestSize;
     private final boolean ignoreUnknownHeaders;
+    private final boolean ignoreUnknownParameters;
     private final boolean corsAllowAll;
     private final XMLOutputFactory xmlOutputFactory =
             XMLOutputFactory.newInstance();
@@ -220,7 +221,7 @@ public class S3ProxyHandler {
             AuthenticationType authenticationType, final String identity,
             final String credential, Optional<String> virtualHost,
             long v4MaxNonChunkedRequestSize, boolean ignoreUnknownHeaders,
-            boolean corsAllowAll) {
+            boolean ignoreUnknownParameters, boolean corsAllowAll) {
         if (identity != null) {
             anonymousIdentity = false;
             blobStoreLocator = new BlobStoreLocator() {
@@ -249,6 +250,7 @@ public class S3ProxyHandler {
         this.virtualHost = requireNonNull(virtualHost);
         this.v4MaxNonChunkedRequestSize = v4MaxNonChunkedRequestSize;
         this.ignoreUnknownHeaders = ignoreUnknownHeaders;
+        this.ignoreUnknownParameters = ignoreUnknownParameters;
         this.corsAllowAll = corsAllowAll;
         this.defaultBlobStore = blobStore;
         xmlOutputFactory.setProperty("javax.xml.stream.isRepairingNamespaces",
@@ -455,6 +457,9 @@ public class S3ProxyHandler {
         // emit NotImplemented for unknown parameters
         for (String parameter : Collections.list(
                 request.getParameterNames())) {
+            if (ignoreUnknownParameters) {
+                continue;
+            }
             if (!SUPPORTED_PARAMETERS.contains(parameter)) {
                 logger.error("Unknown parameters {} with URI {}",
                         parameter, request.getRequestURI());

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandlerJetty.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandlerJetty.java
@@ -44,10 +44,10 @@ final class S3ProxyHandlerJetty extends AbstractHandler {
             AuthenticationType authenticationType, final String identity,
             final String credential, Optional<String> virtualHost,
             long v4MaxNonChunkedRequestSize, boolean ignoreUnknownHeaders,
-            boolean corsAllowAll) {
+            boolean ignoreUnknownParameters, boolean corsAllowAll) {
         handler = new S3ProxyHandler(blobStore, authenticationType, identity,
                 credential, virtualHost, v4MaxNonChunkedRequestSize,
-                ignoreUnknownHeaders, corsAllowAll);
+                ignoreUnknownHeaders, ignoreUnknownParameters, corsAllowAll);
     }
 
     @Override


### PR DESCRIPTION
Presigned URLs may contain additional parameters in the URL which will
be used “as is” by the client uploading/downloading content from S3.

CLOSES #138