### PR TITLE
changes for java 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.7</java.version>
+    <java.version>1.8</java.version>
     <jclouds.version>2.0.1</jclouds.version>
     <slf4j.version>1.7.23</slf4j.version>
     <surefire.version>2.19.1</surefire.version>

--- a/src/main/java/org/gaul/s3proxy/S3Proxy.java
+++ b/src/main/java/org/gaul/s3proxy/S3Proxy.java
@@ -21,8 +21,8 @@ import static java.util.Objects.requireNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.net.URI;
+import java.util.Optional;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -103,7 +103,7 @@ public final class S3Proxy {
         }
         handler = new S3ProxyHandlerJetty(builder.blobStore,
                 builder.authenticationType, builder.identity,
-                builder.credential, Optional.fromNullable(builder.virtualHost),
+                builder.credential, Optional.ofNullable(builder.virtualHost),
                 builder.v4MaxNonChunkedRequestSize,
                 builder.ignoreUnknownHeaders, builder.ignoreUnknownParameters,
                 builder.corsAllowAll);

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -35,12 +35,14 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TimeZone;
@@ -59,7 +61,6 @@ import javax.xml.stream.XMLStreamWriter;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -1605,7 +1606,7 @@ public class S3ProxyHandler {
         if (contentMD5String != null) {
             try {
                 contentMD5 = HashCode.fromBytes(
-                        BaseEncoding.base64().decode(contentMD5String));
+                        Base64.getDecoder().decode(contentMD5String));
             } catch (IllegalArgumentException iae) {
                 throw new S3Exception(S3ErrorCode.INVALID_DIGEST, iae);
             }
@@ -1781,7 +1782,7 @@ public class S3ProxyHandler {
         } catch (InvalidKeyException | NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
-        String expectedSignature = BaseEncoding.base64().encode(
+        String expectedSignature = Base64.getEncoder().encodeToString(
                 mac.doFinal(policy));
         if (!signature.equals(expectedSignature)) {
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
@@ -2255,7 +2256,7 @@ public class S3ProxyHandler {
         if (contentMD5String != null) {
             try {
                 contentMD5 = HashCode.fromBytes(
-                        BaseEncoding.base64().decode(contentMD5String));
+                        Base64.getDecoder().decode(contentMD5String));
             } catch (IllegalArgumentException iae) {
                 throw new S3Exception(S3ErrorCode.INVALID_DIGEST, iae);
             }
@@ -2541,7 +2542,7 @@ public class S3ProxyHandler {
         } catch (InvalidKeyException | NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
-        return BaseEncoding.base64().encode(mac.doFinal(
+        return Base64.getEncoder().encodeToString(mac.doFinal(
                 stringToSign.getBytes(StandardCharsets.UTF_8)));
     }
 

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandlerJetty.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandlerJetty.java
@@ -18,12 +18,12 @@ package org.gaul.s3proxy;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
 import org.eclipse.jetty.server.Request;


### PR DESCRIPTION
Changes done to move to java 1.8.

This project uses a moderniser-maven-plugin which showed the below issues. I resolved them in this pull request.

```
[ERROR] /Users/sthakur/s3proxy/src/main/java/org/gaul/s3proxy/S3Proxy.java:106: Prefer java.util.Optional
[ERROR] /Users/sthakur/s3proxy/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java:1583: Prefer java.util.Base64.Decoder or java.util.Base64.Encoder
[ERROR] /Users/sthakur/s3proxy/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java:1759: Prefer java.util.Base64.Decoder or java.util.Base64.Encoder
[ERROR] /Users/sthakur/s3proxy/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java:2233: Prefer java.util.Base64.Decoder or java.util.Base64.Encoder
[ERROR] /Users/sthakur/s3proxy/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java:2519: Prefer java.util.Base64.Decoder or java.util.Base64.Encoder
```