### PR TITLE
Error messages are now printed using logger.error instead of System.error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,11 @@
       <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-exec</artifactId>
+      <version>1.3</version>
+    </dependency>
     <!-- tests dependencies -->
     <dependency>
       <groupId>org.apache.jclouds</groupId>

--- a/src/main/java/org/gaul/s3proxy/Main.java
+++ b/src/main/java/org/gaul/s3proxy/Main.java
@@ -34,6 +34,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
 import com.google.inject.Module;
 
+import org.apache.commons.exec.LogOutputStream;
 import org.jclouds.Constants;
 import org.jclouds.ContextBuilder;
 import org.jclouds.JcloudsVersion;
@@ -246,11 +247,12 @@ public final class Main {
     }
 
     private static PrintStream createLoggerErrorPrintStream() {
-        return new PrintStream(System.err) {
-            public void print(final String string) {
-                logger.error(string);
+        return new PrintStream(new LogOutputStream() {
+            @Override
+            protected void processLine(String s, int i) {
+                logger.error(s);
             }
-        };
+        });
     }
 
     private static BlobStore createBlobStore(Properties properties)

--- a/src/main/java/org/gaul/s3proxy/Main.java
+++ b/src/main/java/org/gaul/s3proxy/Main.java
@@ -16,10 +16,12 @@
 
 package org.gaul.s3proxy;
 
+import java.io.Console;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -43,8 +45,11 @@ import org.jclouds.openstack.swift.v1.blobstore.RegionScopedBlobStoreContext;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class Main {
+    private static final Logger logger = LoggerFactory.getLogger(Main.class);
     private Main() {
         throw new AssertionError("intentionally not implemented");
     }
@@ -59,6 +64,11 @@ public final class Main {
     }
 
     public static void main(String[] args) throws Exception {
+        Console console = System.console();
+        if (console == null) {
+            System.setErr(createLoggerErrorPrintStream());
+        }
+
         Options options = new Options();
         CmdLineParser parser = new CmdLineParser(options);
         try {
@@ -233,6 +243,14 @@ public final class Main {
             System.err.println(e.getMessage());
             System.exit(1);
         }
+    }
+
+    private static PrintStream createLoggerErrorPrintStream() {
+        return new PrintStream(System.err) {
+            public void print(final String string) {
+                logger.error(string);
+            }
+        };
     }
 
     private static BlobStore createBlobStore(Properties properties)


### PR DESCRIPTION
Using logger for printing messages make it consistent. And it also makes sure all logs go through same logging configuration (logback.xml) which has the s3 prefix in it. Using println will bypass it.