### PR TITLE
Fixed failing test in case of azure

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -658,9 +658,18 @@ public class S3ProxyHandler {
             } else {
                 String containerName = path[1];
                 String blobName = path[2];
-                BlobAccess access = blobStore.getBlobAccess(containerName,
-                        blobName);
-                if (access != BlobAccess.PUBLIC_READ) {
+                boolean publicAccess = false;
+                String blobStoreType = getBlobStoreType(blobStore);
+                if (Quirks.NO_BLOB_ACCESS_CONTROL.contains(blobStoreType)) {
+                    ContainerAccess access = blobStore.getContainerAccess(
+                            containerName);
+                    publicAccess = access == ContainerAccess.PUBLIC_READ;
+                } else {
+                    BlobAccess access = blobStore.getBlobAccess(containerName,
+                            blobName);
+                    publicAccess = access == BlobAccess.PUBLIC_READ;
+                }
+                if (!publicAccess) {
                     throw new S3Exception(S3ErrorCode.ACCESS_DENIED);
                 }
                 handleGetBlob(request, response, blobStore, containerName,

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -635,6 +635,20 @@ public class S3ProxyHandler {
         throw new S3Exception(S3ErrorCode.NOT_IMPLEMENTED);
     }
 
+    private boolean checkPublicAccess(BlobStore blobStore,
+            String containerName, String blobName) {
+        String blobStoreType = getBlobStoreType(blobStore);
+        if (Quirks.NO_BLOB_ACCESS_CONTROL.contains(blobStoreType)) {
+            ContainerAccess access = blobStore.getContainerAccess(
+                    containerName);
+            return access == ContainerAccess.PUBLIC_READ;
+        } else {
+            BlobAccess access = blobStore.getBlobAccess(containerName,
+                    blobName);
+            return access == BlobAccess.PUBLIC_READ;
+        }
+    }
+
     private void doHandleAnonymous(HttpServletRequest request,
             HttpServletResponse response, InputStream is, String uri,
             BlobStore blobStore)
@@ -658,18 +672,7 @@ public class S3ProxyHandler {
             } else {
                 String containerName = path[1];
                 String blobName = path[2];
-                boolean publicAccess = false;
-                String blobStoreType = getBlobStoreType(blobStore);
-                if (Quirks.NO_BLOB_ACCESS_CONTROL.contains(blobStoreType)) {
-                    ContainerAccess access = blobStore.getContainerAccess(
-                            containerName);
-                    publicAccess = access == ContainerAccess.PUBLIC_READ;
-                } else {
-                    BlobAccess access = blobStore.getBlobAccess(containerName,
-                            blobName);
-                    publicAccess = access == BlobAccess.PUBLIC_READ;
-                }
-                if (!publicAccess) {
+                if (!checkPublicAccess(blobStore, containerName, blobName)) {
                     throw new S3Exception(S3ErrorCode.ACCESS_DENIED);
                 }
                 handleGetBlob(request, response, blobStore, containerName,
@@ -690,9 +693,7 @@ public class S3ProxyHandler {
             } else {
                 String containerName = path[1];
                 String blobName = path[2];
-                BlobAccess access = blobStore.getBlobAccess(containerName,
-                        blobName);
-                if (access != BlobAccess.PUBLIC_READ) {
+                if (!checkPublicAccess(blobStore, containerName, blobName)) {
                     throw new S3Exception(S3ErrorCode.ACCESS_DENIED);
                 }
                 handleBlobMetadata(request, response, blobStore, containerName,


### PR DESCRIPTION
For blob stores for which there is no blob access control, testHttpClient test is failing. For these blob stores by default getBlobAccess returns private. If a bucket is public then we should allow public access of the blob. This pull request fixes this issue